### PR TITLE
typically, dispersion = 1 / size

### DIFF
--- a/R/NB.R
+++ b/R/NB.R
@@ -5,7 +5,7 @@
 #' @param  seed optional seed to set before drawing
 NB = function(basemeans, dispersion_param, seed=NULL){
     if(!is.null(seed)) set.seed(seed)
-    numreads = rnbinom(n = length(basemeans), mu = basemeans, size = dispersion_param)
+    numreads = rnbinom(n = length(basemeans), mu = basemeans, size = 1/dispersion_param)
     numreads[numreads == 0] = 1
     return(numreads)
 }


### PR DESCRIPTION
Typically dispersion of a negative binomial is 1/size for the size arg of the rnbinom function.

This way, for fixed mu, larger dispersion corresponds to larger variance.

If you accept this change you'd have to fix the man pages for NB and simulate_experiment.
