### PR TITLE
Math error with logmus of meanmodel

### DIFF
--- a/R/simulate_experiment.R
+++ b/R/simulate_experiment.R
@@ -314,7 +314,7 @@ simulate_experiment = function(fasta=NULL, gtf=NULL, seqpath=NULL,
         b0 = -3.0158
         b1 = 0.8688
         sigma = 4.152
-        logmus = b0 + b1*width(transcripts) + rnorm(length(transcripts),0,sigma)
+        logmus = b0 + b1*log2(width(transcripts)) + rnorm(length(transcripts),0,sigma)
         reads_per_transcript = 2^logmus-1
     }
     basemeans = ceiling(reads_per_transcript * fold_changes)


### PR DESCRIPTION
Hi Alyssa,

I was excited to try your package after taking Dr. Leek's Coursera series, and finding your work after looking for a way to simulate RNA-Seq data. However, I received an error when I attempted to use `simulate_experiment()` with `meanmodel=TRUE`. Digging into the code, I found that the `reads_per_transcript parameter` had several "Inf" values, which was generated from `logmus` exponents that were way too high (>1K). Reviewing your document describing where the linear regression came from (http://htmlpreview.github.io/?https://github.com/alyssafrazee/polyester_code/blob/master/length_simulation.html), I saw that the linear regression was of the log2 of the widths of the transcripts, and that this is missing in your original code. Let me know if I modified the code correctly.

Thanks,
Warren