### PR TITLE
Keep reads_per_transcript positive

### DIFF
--- a/R/simulate_experiment.R
+++ b/R/simulate_experiment.R
@@ -362,6 +362,7 @@ simulate_experiment = function(fasta=NULL, gtf=NULL, seqpath=NULL,
         sigma = 4.152
         logmus = b0 + b1*log2(width(transcripts)) + rnorm(length(transcripts),0,sigma)
         reads_per_transcript = 2^logmus-1
+        reads_per_transcript = pmax( reads_per_transcript, 1e-6 )
     }
 
     if(length(num_reps) == 1){


### PR DESCRIPTION
When using 'meanmodel=T', the reads_per_transcript in simulate_experiments() might be non-positive. If the number is non-positive, we will get warnings about NA from NB() and errors about "rep(...): invalid 'times' argument" when generating reads.

So I added a line to keep reads_per_trancript positive, is this valid?

Thanks,
Li