### PR TITLE
bugfix - avoids duplicated read IDs

### DIFF
--- a/R/sgseq.R
+++ b/R/sgseq.R
@@ -21,7 +21,7 @@ sgseq = function(readmat, transcripts, paired, outdir, extras, reportCoverage=FA
     iterations = ceiling(length(tObj) / 1e6L)
     offset = 1L
     for(iteration in seq_len(iterations)) {
-      tSubset = tObj[offset:min(offset+1e6L, length(tObj))]
+      tSubset = tObj[offset:min(offset+999999L, length(tObj))] ## corrected value of integer added to offset to avoid duplicating reads
       tFrags = generate_fragments(tSubset, extras$fraglen[i], extras$fragsd[i],
                                   extras$readlen, extras$distr, extras$custdens,
                                   extras$bias, frag_GC_bias)


### PR DESCRIPTION
Hi, 
as I commented on #50, I tested yesterday the sgseq.R function and found out that the problem comes from adding 1e6 to the offset value in the interations loop, as in each iteration it was creating 1000001 reads instead of 1e6. Changing the value for 999999 does the trick to avoid extra reads with duplicated IDs.